### PR TITLE
Fix cases: echo "", echo ''. Output should be an empty line in terminal.

### DIFF
--- a/src/parser/parse.c
+++ b/src/parser/parse.c
@@ -94,7 +94,7 @@ int	count_pipes(t_data *data)
 	npipes = 0;
 	while (this->str != NULL)
 	{
-		if (ft_strncmp(this->str, "|", ft_strlen(this->str)) == 0)
+		if (ft_strncmp(this->str, "|", 2) == 0)
 			npipes++;
 		this = this->next;
 	}


### PR DESCRIPTION
Not sure, if this change doesn't destroy smth in pipes.